### PR TITLE
Improve performance of fqcnt_jl1_klib.jl

### DIFF
--- a/fqcnt/fqcnt_jl1_klib.jl
+++ b/fqcnt/fqcnt_jl1_klib.jl
@@ -11,8 +11,8 @@ function main(args)
 	n, slen, qlen = 0, 0, 0
 	while (r = read(fx)) != nothing
 		n += 1
-		slen += length(r.seq)
-		qlen += length(r.qual)
+		slen += sizeof(r.seq)
+		qlen += sizeof(r.qual)
 	end
 	println(n, "\t", slen, "\t", qlen)
 end

--- a/lib/Klib.jl
+++ b/lib/Klib.jl
@@ -118,7 +118,7 @@ function destroy!(b::ByteBuffer)
 	return ret
 end
 
-tostring(b::ByteBuffer, n::Int) = String(unsafe_wrap(Vector{UInt8}, b.a, n))
+tostring(b::ByteBuffer, n::Int) = unsafe_string(b.a, n)
 
 #
 # GzFile

--- a/lib/Klib.jl
+++ b/lib/Klib.jl
@@ -202,7 +202,7 @@ function readbyte(r::Bufio{T}) where {T<:IO}
 	end
 	c = r.buf[r.start]
 	r.start += 1
-	return c
+	return c % Int
 end
 
 trimret(buf::ByteBuffer, n) = n > 0 && unsafe_load(buf.a, n) == 0x0d ? n - 1 : n # remove trailing '\r' if present


### PR DESCRIPTION
Hi, I've slightly improved the performance of fqcnt_jl1_klib.jl. 

Here are the step-by-step improvements from 759cd6a to 15d9864 on my machine:
```
HEAD is now at 759cd6a use bit operators
Benchmark #1: fqcnt/fqcnt_jl1_klib.jl biofast-data-v1/M_abscessus_HiSeq.fq
  Time (mean ± σ):      4.280 s ±  0.083 s    [User: 3.923 s, System: 0.838 s]
  Range (min … max):    4.134 s …  4.398 s    10 runs
 
Previous HEAD position was 759cd6a use bit operators
HEAD is now at 7fd4ff8 make readbyte type stable
Benchmark #1: fqcnt/fqcnt_jl1_klib.jl biofast-data-v1/M_abscessus_HiSeq.fq
  Time (mean ± σ):      3.717 s ±  0.074 s    [User: 3.390 s, System: 0.793 s]
  Range (min … max):    3.620 s …  3.834 s    10 runs
 
Previous HEAD position was 7fd4ff8 make readbyte type stable
HEAD is now at f1b09c2 do not count  string length twice
Benchmark #1: fqcnt/fqcnt_jl1_klib.jl biofast-data-v1/M_abscessus_HiSeq.fq
  Time (mean ± σ):      2.834 s ±  0.046 s    [User: 2.513 s, System: 0.805 s]
  Range (min … max):    2.769 s …  2.936 s    10 runs
 
Previous HEAD position was f1b09c2 do not count  string length twice
HEAD is now at 2984dc8 use unsafe_string to make strings
Benchmark #1: fqcnt/fqcnt_jl1_klib.jl biofast-data-v1/M_abscessus_HiSeq.fq
  Time (mean ± σ):      2.380 s ±  0.026 s    [User: 2.101 s, System: 0.755 s]
  Range (min … max):    2.331 s …  2.411 s    10 runs
 
Previous HEAD position was 2984dc8 use unsafe_string to make strings
HEAD is now at 15d9864 use memchr to find delimiter
Benchmark #1: fqcnt/fqcnt_jl1_klib.jl biofast-data-v1/M_abscessus_HiSeq.fq
  Time (mean ± σ):      1.893 s ±  0.040 s    [User: 1.615 s, System: 0.756 s]
  Range (min … max):    1.842 s …  1.995 s    10 runs
 ```

```
julia> versioninfo()
Julia Version 1.4.1
Commit 381693d3df* (2020-04-14 17:20 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: AMD Ryzen 5 2400G with Radeon Vega Graphics
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-8.0.1 (ORCJIT, znver1)
Environment:
  JULIA_PROJECT = @.
```