### PR TITLE
Do not flush buffer every newline

### DIFF
--- a/bedcov/bedcov_cr1_klib.cr
+++ b/bedcov/bedcov_cr1_klib.cr
@@ -6,6 +6,7 @@ if ARGV.size < 2
 end
 
 include Klib
+STDOUT.flush_on_newline = false
 
 alias SType = Int32
 bed = Hash(String, Array(IITree::Interval(SType, Int32))).new


### PR DESCRIPTION
Adding `STDOUT.flush_on_newline = false` to the crystal bedcov implementation otherwise it flushes every line. On my laptop this gives bedcov nearly a 3.5 second speedup.

Relevant issue / forum posts from Crystal:
- https://github.com/crystal-lang/crystal/issues/7431
- https://forum.crystal-lang.org/t/crystal-0-34-0-slower/2124/43