### PR TITLE
bump rustbio version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 flate2 = "1.0.14"
-bio = "0.30.1"
+bio = "0.31.0"
 needletail = "0.3.2"
 
 [[bin]]


### PR DESCRIPTION
v0.31.0 now handles line-wrapped fastq files. Locally, it also runs a little faster than the previous version did (the parsing logic has changed a little with the version bump)