### PR TITLE
add fqcnt_go2.go

### DIFF
--- a/fqcnt/Makefile
+++ b/fqcnt/Makefile
@@ -21,6 +21,11 @@ fqcnt_nim1_klib:fqcnt_nim1_klib.nim ../lib/klib.nim
 fqcnt_go1:fqcnt_go1.go
 	$(GO) build $<
 
+fqcnt_go2:fqcnt_go2.go
+	$(GO) get -u github.com/shenwei356/bio
+	$(GO) mod tidy
+	CGO_ENABLED=0 $(GO) build -tags netgo -ldflags '-w -s' -asmflags '-trimpath' $<
+
 .PHONY: fqcnt_rs
 fqcnt_rs:
 	$(CARGO) install --path $(PROJECT_ROOT) --force --bin fqcnt_rustbio --bin fqcnt_needletail --root .
@@ -49,3 +54,4 @@ fqcnt_scala_jar_fgbio: scala/tools/src/com/github/biofast/FgBio.scala
 
 clean:
 	rm -fr *.dSYM $(PROG)
+	rm -fr go.sum

--- a/fqcnt/README.md
+++ b/fqcnt/README.md
@@ -12,6 +12,7 @@
 |[fqcnt\_js1\_k8.js](fqcnt_js1_k8.js)          |Javascript|                            | 17.5|  9.4|kseq.h port|
 |[fqcnt\_py7x\_pysam.py](fqcnt_py7x_pysam.py)  |Python    |[pysam][pysam]              | 18.5| 12.7|kseq.h binding|
 |[fqcnt\_go1.go](fqcnt_go1.go)                 |Go        |                            | 19.1|  2.8|4-line only|
+|[fqcnt\_go2.go](fqcnt_go2.go)                 |Go        |[bio][bio]                  |     |     |bio        |
 |[fqcnt\_jl2x\_fastx.jl](fqcnt_jl2x_fastx.jl)  |Julia     |[Fastx.jl][fx.jl]           | 19.5|  2.6|4-line only; no startup|
 |[fqcnt\_lua2\_4l.lua](fqcnt_lua2_4l.lua)      |LuaJIT    |                            | 22.8| 10.4|4-line only|
 |[fqcnt\_py8x\_fx.py](fqcnt_py8x_fx.py)        |Python    |[Fastx][fx.py]; cffi        | 24.2| 15.9|kseq.h binding|
@@ -63,3 +64,4 @@
 [fgbio]: http://fulcrumgenomics.github.io/fgbio/
 [commons.io]: https://javadoc.io/static/com.fulcrumgenomics/commons_2.12/1.0.0/com/fulcrumgenomics/commons/io/Io$.html#readLinesFromResource(name:String):Iterator[String]
 [ammnoite]: http://ammonite.io/
+[bio]: https://github.com/shenwei356/bio

--- a/fqcnt/fqcnt_go2.go
+++ b/fqcnt/fqcnt_go2.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/shenwei356/bio/seq"
+	"github.com/shenwei356/bio/seqio/fastx"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Println("Usage: fqcnt_go2 in.fq.gz")
+		os.Exit(1)
+	}
+	fn := os.Args[1]
+
+	n, slen, qlen := 0, 0, 0
+
+	seq.ValidateSeq = false // do not check bases
+	fastxReader, err := fastx.NewDefaultReader(fn)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	var record *fastx.Record
+	for {
+		record, err = fastxReader.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			fmt.Println(err)
+			os.Exit(1)
+			break
+		}
+
+		n++
+		slen += len(record.Seq.Seq)
+		qlen += len(record.Seq.Qual)
+	}
+
+	fmt.Printf("%v\t%v\t%v\n", n, slen, qlen)
+}

--- a/fqcnt/go.mod
+++ b/fqcnt/go.mod
@@ -1,0 +1,13 @@
+module github.com/shenwei356/biofast
+
+go 1.17
+
+require github.com/shenwei356/bio v0.3.3
+
+require (
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/shenwei356/bpool v0.0.0-20160710042833-f9e0ee4d0403 // indirect
+	github.com/shenwei356/util v0.4.0 // indirect
+	github.com/shenwei356/xopen v0.1.0 // indirect
+)


### PR DESCRIPTION
Added a faster Go version using [bio](https://github.com/shenwei356/bio) lib. It's compiled with [go 1.17](https://golang.org/dl/)

Benchmark (CPU: AMD Ryzen 7 2700X Eight-Core Processor, 3.7 GHz)

|app             |gzip  |plain|
|:---------------|:-----|:----|
|fqcnt_needletail|5.924 |0.733|
|fqcnt_c1_kseq   |7.402 |1.115|
|fqcnt_rustbio   |7.413 |2.331|
|fqcnt_nim1_klib |8.059 |1.781|
|*fqcnt_go2*       |8.987 |1.166|
|fqcnt_go1       |23.058|3.534|

The Go standard library that `gzip` `fqcnt_go1` uses is very slow, `fqcnt_go2` uses a [faster version](https://github.com/klauspost/compress).